### PR TITLE
Update Nether Quartz Biome Whitelist

### DIFF
--- a/config/cofh/world/Vanilla.json
+++ b/config/cofh/world/Vanilla.json
@@ -146,7 +146,7 @@
         "retrogen": "true",
         "biomeRestriction": "whitelist",
         "biomes": [
-            "hell"
+            "Hell"
         ],
         "dimensionRestriction": "whitelist",
         "dimensions": [


### PR DESCRIPTION
Fixes lack of quartz gen in nether by correcting capitalization of "Hell" biome in Vanilla.json
